### PR TITLE
Fix Windows bootstrap download instructions

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 GRAPH
   build-essential (2.2.3)
   chef_handler (1.2.0)
-  chefdk_bootstrap (1.2.1)
+  chefdk_bootstrap (1.2.3)
     chocolatey (~> 0.4)
     git (~> 4.3)
     homebrew (~> 1.13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision History for chefdk_bootstrap
 
+## 1.2.3
+* Make non-proxy README instructions work for Windows. Fixes #35
+* Clear screen as first step in bootstrap script. Fixes #34
+
 ## 1.2.2
 * Add Apache 2.0 license header.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       serverspec (~> 2.7)
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
-    chef (12.4.1-x86-mingw32)
+    chef (12.4.1-universal-mingw32)
       chef-config (= 12.4.1)
       chef-zero (~> 4.2, >= 4.2.2)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -203,7 +203,7 @@ GEM
     mixlib-config (2.2.1)
     mixlib-log (1.6.0)
     mixlib-shellout (2.1.0)
-    mixlib-shellout (2.1.0-x86-mingw32)
+    mixlib-shellout (2.1.0-universal-mingw32)
       win32-process (~> 0.7.5)
       windows-pr (~> 1.2.4)
     multi_json (1.11.2)
@@ -267,7 +267,7 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    retryable (2.0.1)
+    retryable (2.0.2)
     ridley (4.2.0)
       addressable
       buff-config (~> 1.0)
@@ -330,7 +330,7 @@ GEM
     solve (1.2.1)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
-    specinfra (2.40.2)
+    specinfra (2.41.1)
       net-scp
       net-ssh (~> 2.7)
       net-telnet
@@ -352,7 +352,7 @@ GEM
     varia_model (0.4.0)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 3.0.0)
-    win32-api (1.5.3-x86-mingw32)
+    win32-api (1.5.3-universal-mingw32)
     win32-dir (0.5.0)
       ffi (>= 1.0.0)
     win32-event (0.6.1)
@@ -375,7 +375,7 @@ GEM
     windows-pr (1.2.4)
       win32-api (>= 1.4.5)
       windows-api (>= 0.4.0)
-    winrm (1.3.3)
+    winrm (1.3.4)
       builder (>= 2.1.2)
       gssapi (~> 1.2)
       gyoku (~> 1.0)
@@ -415,3 +415,6 @@ DEPENDENCIES
   ruby_gntp (~> 0.3)
   test-kitchen (~> 1.4)
   winrm-transport (~> 1.0)
+
+BUNDLED WITH
+   1.10.0

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ for Chef cookbook development in about **20 minutes**.
 
 ## Quickstart Windows
 
-Copy the PowerShell command below and paste them into a **PowerShell Admin** console. This will execute the [bootstrap](https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap.ps1)
+Copy the PowerShell command below and paste them into a **PowerShell Admin** console. This will download and run the [bootstrap](https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap.ps1)
 script on your workstation.
 
 ```PowerShell
- (Invoke-WebRequest -Uri https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap.ps1 -ProxyUseDefaultCredentials -Proxy $env:https_proxy).Content | Invoke-Expression
+ (Invoke-WebRequest -Uri https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap.ps1).Content | Invoke-Expression
 ```
 
 ## Quickstart Mac
 
-Copy the command below and paste it into a terminal. This will execute the [bootstrap](https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap) script on your workstation.
+Copy the command below and paste it into a terminal. This will download and run the [bootstrap](https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap) script on your workstation.
 
 ```bash
 curl https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap | bash
@@ -32,20 +32,33 @@ Follow the instructions in the [ChefDK README](https://github.com/chef/chef-dk#u
 
 ## If you are behind a proxy
 ### Windows
+
+#### Set Proxy Environment Vars
 Copy/paste these environment variables into your terminal.
 
 ```PowerShell
 # change these values to your proxy address
 $env:http_proxy='http://myproxy.example.com:1234'
 ```
+
 ```PowerShell
 $env:https_proxy=$env:http_proxy
 ```
+
 ```PowerShell
 # don't go through the proxy for these addresses.
+# change example.com to your corporate DNS domain
 $env:no_proxy='localhost,127.0.0.1,example.com'
 ```
-Now run the [Quickstart for Windows](#quickstart-windows)
+
+#### Use this proxy-aware bootstrap script
+Copy the PowerShell command below and paste them into a **PowerShell Admin** console. This will execute the [bootstrap](https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap.ps1)
+script on your workstation.
+
+```PowerShell
+ (Invoke-WebRequest -Uri https://raw.githubusercontent.com/Nordstrom/chefdk_bootstrap/master/bootstrap.ps1 -ProxyUseDefaultCredentials -Proxy $env:https_proxy).Content | Invoke-Expression
+```
+
 ### Mac
 Copy/paste these environment variables into your terminal.
 
@@ -53,11 +66,14 @@ Copy/paste these environment variables into your terminal.
 # change these values to your proxy address
 export http_proxy=http://myproxy.example.com:1234
 ```
+
 ```bash
 export https_proxy=$http_proxy
 ```
 
 ```bash
+# don't go through the proxy for these addresses.
+# change example.com to your corporate DNS domain
 export no_proxy='localhost,127.0.0.1,example.com'
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for Chef cookbook development in about **20 minutes**.
 ## Before You Begin
 * If you are on a Windows machine, you will need at least PowerShell 3.0. We recommend [PowerShell 4.0](http://www.microsoft.com/en-us/download/details.aspx?id=40855) because it supports [Microsoft DSC](https://technet.microsoft.com/en-us/%5Clibrary/Dn249912.aspx).
 
-* If you are behind a proxy, you will need to export [these environment variables](#if-you-are-behind-a-proxy) first.
+* If you are behind a proxy, you will need to export these [proxy environment variables](#if-you-are-behind-a-proxy) first.
 
 ## Quickstart Windows
 

--- a/bootstrap
+++ b/bootstrap
@@ -26,6 +26,8 @@ private_source=${2:+source '$2'}
 # make userChefDir variable
 userChefDir=~/chef
 
+clear
+
 # introduction
 cat <<EOF;
 This script will:

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -55,6 +55,8 @@ $introduction = @"
 
 "@
 
+Clear-Host
+
 Write-Host $introduction
 
 # create the chef directory
@@ -73,7 +75,7 @@ Write-Host 'Installing ChefDK...'
 Start-Process -Wait -FilePath msiexec.exe -ArgumentList /qb, /i, $chefDkSource
 
 # Add ChefDK to the path
-$env:Path += ";c:\opscode\chefdk\bin"
+$env:Path += ";C:\opscode\chefdk\bin"
 
 Set-Location $userChefDir
 
@@ -104,5 +106,5 @@ if (Test-Path berks-cookbooks) {
   Remove-Item -Recurse berks-cookbooks
 }
 
-#End message to indicate completion of setup
-Write-Host 'Congrats!!! Your workstation is now set up for Chef Development!'
+# End message to indicate completion of setup
+Write-Host "`n`nCongrats!!! Your workstation is now set up for Chef Development!"

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer       'Nordstrom, Inc.'
 maintainer_email 'techcheftm@nordstrom.com'
 license          'Apache 2.0'
 description      'Bootstrap a developer workstation for local Chef development using the ChefDK'
-version          '1.2.2'
+version          '1.2.3'
 
 supports 'windows'
 supports 'mac_os_x'


### PR DESCRIPTION
* Make proxy and non-proxy README instructions work for Windows. Fixes #35
* Clear screen as first step in bootstrap script. Fixes #34