### PR TITLE
Possibly use Requires instead of If block

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(`
-  [Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    Write-Warning "You do not have Administrator rights to run this script!`nPlease re-run this script as an Administrator!"
-    Break
-}
+#Requires -Version 3.0
+#Requires -RunAsAdministrator
 
 $targetChefDk = '0.10.0'
 $bootstrapCookbook = 'chefdk_bootstrap'

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 #Requires -Version 3.0
-#Requires -RunAsAdministrator
+
+if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(`
+  [Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    Write-Warning "You do not have Administrator rights to run this script!`nPlease re-run this script as an Administrator!"
+    Break
+}
 
 $targetChefDk = '0.10.0'
 $bootstrapCookbook = 'chefdk_bootstrap'


### PR DESCRIPTION
The check in the if block for security principle works, but there is a simpler way if you are already requiring PS 3.0 or higher. [Requires](https://technet.microsoft.com/en-us/library/hh847765.aspx) make this kind of check extremely easy.

No offense taken if you don't want to go this route.