### PR TITLE
Refactor Mac bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision History for chefdk_bootstrap
 
+## Unreleased
+* Bootstrap: create temporary directory using `mktemp -d`
+* Stop creating ~/.chef, ~/chef, and ~/chef/cookbooks directories in bootstrap script
+since creating these directories has been moved to the cookbook.
+
 ## 1.5.2
 * Bump homebrew dependency to ~> 2.0 because Homebrew cookbook v2.0.4 fixes
 chef-cookbooks/homebrew#87. This will fix the bootstrap for Mac users.

--- a/bootstrap
+++ b/bootstrap
@@ -112,7 +112,7 @@ sudo -E chef-client -z -l error -c "${tempInstallDir}/client.rb" -o "$bootstrapC
 cd -
 rm -rf "$tempInstallDir"
 
-#End message to direct Mac users to last step in set up
+# End message to direct Mac users to last step in set up
 cat <<EOF;
 You're almost done!!! You just need to edit your shell startup script to set up
 chefdk environment variables for each login. See this page:

--- a/bootstrap
+++ b/bootstrap
@@ -38,10 +38,6 @@ bootstrapCookbook=${1:-chefdk_bootstrap}
 # If the user has passed in a private supermarket url then add it to the Berksfile
 private_source=${2:+source \'$2\'}
 
-# make temp installation directory variable
-tempInstallDir="/tmp/chefdk_bootstrap_$$"
-[[ ! -d "$tempInstallDir" ]] && mkdir "$tempInstallDir"
-
 clear
 
 # introduction
@@ -49,18 +45,11 @@ cat <<EOF;
 This script will:
 
 1. Install the latest ChefDK package
-2. Create some chef directories in your user profile (home) directory
-    ~/.chef
-    ~/chef
-    ~/chef/cookbooks
-3. Download the 'chefdk_bootstrap' cookbook via Berkshelf
-4. Run 'chef-client' to install the rest of the tools you will need
+2. Download the 'chefdk_bootstrap' cookbook via Berkshelf
+3. Run 'chef-client' to install the rest of the tools you will need
 EOF
 
-#NOTE: this should be moved into the mac_os_x recipe, issue #43
-[[ ! -d ~/.chef ]] && mkdir ~/.chef
-[[ ! -d ~/chef ]] && mkdir ~/chef
-[[ ! -d ~/chef/cookbooks ]] && mkdir ~/chef/cookbooks
+tempInstallDir=`mktemp -d -t chefdk_bootstrap`
 
 # create Berksfile so that we can install the correct cookbook dependencies
 cat > "${tempInstallDir}/Berksfile" <<EOF;
@@ -121,11 +110,7 @@ sudo -E chef-client -z -l error -c "${tempInstallDir}/client.rb" -o "$bootstrapC
 
 # cleanup
 cd -
-rm -f "$tempInstallDir/Berksfile"
-rm -f "$tempInstallDir/Berksfile.lock"
-rm -f "$tempInstallDir/client.rb"
-rm -rf "$tempInstallDir/berks-cookbooks"
-rmdir "$tempInstallDir"
+rm -rf "$tempInstallDir"
 
 #End message to direct Mac users to last step in set up
 cat <<EOF;


### PR DESCRIPTION
Bootstrap: create temporary directory using `mktemp -d`

Stop creating ~/.chef, ~/chef, and ~/chef/cookbooks directories in bootstrap script
since creating these directories has been moved to the cookbook.

Fixes #43
Fixes #66