### PR TITLE
Let homebrew cookbook create Cask directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Revision History for chefdk_bootstrap
 
-## Unreleased
+## 1.5.3
+* Mac: Don't create directories which homebrew cookbook already creates
 * Bootstrap: create temporary directory using `mktemp -d`
 * Stop creating ~/.chef, ~/chef, and ~/chef/cookbooks directories in bootstrap script
 since creating these directories has been moved to the cookbook.

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ export no_proxy='localhost,127.0.0.1,example.com'
 
 *To make these changes permanent, export these environment variables from your bash or zsh profile.*
 
-Now run the [Quickstart for Mac](#quickstart-mac)
+Now run the [Quickstart for Mac](#mac-quickstart)
 
 ## Customization
-If you want to use your own custom wrapper cookbook, add the name of your cookbook and your private supermarket source to these commands instead of the original [Quickstart](#quickstart-windows) (examples included below).
+If you want to use your own custom wrapper cookbook, add the name of your cookbook and your private supermarket source to these commands instead of the original [Quickstart](#windows-quickstart) (examples included below).
 
 ### JSON attributes
 You can pass in attributes via URL/path to a JSON file (see the --json-attributes option in [chef-client](https://docs.chef.io/ctl_chef_client.html) ). Right now we're passing this in via the `CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES` environment variable, but in a future version, we'll likely make it a named parameter of the bootstrap script.

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer       'Nordstrom, Inc.'
 maintainer_email 'techcheftm@nordstrom.com'
 license          'Apache 2.0'
 description      'Bootstrap a developer workstation for local Chef development using the ChefDK'
-version          '1.5.2'
+version          '1.5.3'
 
 supports 'windows'
 supports 'mac_os_x'

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -19,8 +19,6 @@ home = Dir.home(ENV['SUDO_USER'] || ENV['USER'])
   #{home}/chef
   #{home}/chef/cookbooks
   /usr/local
-  /opt/homebrew-cask
-  /opt/homebrew-cask/Caskroom
 ).each do |dir|
   directory dir do
     owner ENV['SUDO_USER'] || ENV['USER']

--- a/spec/recipes/mac_os_x_spec.rb
+++ b/spec/recipes/mac_os_x_spec.rb
@@ -52,9 +52,6 @@ RSpec.describe 'chefdk_bootstrap::mac_os_x' do
   end
 
   %w(
-    /usr/local
-    /opt/homebrew-cask
-    /opt/homebrew-cask/Caskroom
     /Users/doug/.chef
     /Users/doug/chef
     /Users/doug/chef/cookbooks


### PR DESCRIPTION
Stop creating `/opt/homebrew-cask` and `/opt/homebrew-cask/Caskroom` since the homebrew::cask recipe already does that.

Fixes #85