### PR TITLE
Fix the string output for the JSON URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Use test kitchen to spin up a new VM:
     kitchen create
 
 Then you can test your updated bootstrap.ps1 in the guest VM:
-1. Run PowerShell as Admin
+1. Run `powershell` as Administrator
 2. `notepad bootstrap.ps1` to make a new file
 3. Copy + paste your updated code.
 4. You may want to add proxy environment variables at the top, plus the script below to copy them to the system. (Currently chocolatey doesn't honor proxy settings in environment variables.)

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -137,7 +137,7 @@ if ( -not $? ) { Pop-Location;  die "Error running berks to download cookbooks."
 # Pass optional attributes to chef-client
 # This is a temporary interface and will change in 2.0 when we support named parameters (Issue #74)
 if ($env:CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES) {
-  $attributeParameter = "--json-attributes ${$env:CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES}"
+  $attributeParameter = '--json-attributes "$env:CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES"'
 }
 
 # run chef-client (installed by ChefDK) to bootstrap this machine


### PR DESCRIPTION
Fixing a bug in how the JSON attribute URL is rendered and passed in to chef-client