### PR TITLE
Remove Gitter badge - Fix #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ChefDK_Bootstrap [![Build Status](https://travis-ci.org/Nordstrom/chefdk_bootstrap.svg?branch=master)](https://travis-ci.org/Nordstrom/chefdk_bootstrap)
 
-[![Join the chat at https://gitter.im/Nordstrom/chefdk_bootstrap](https://badges.gitter.im/Nordstrom/chefdk_bootstrap.svg)](https://gitter.im/Nordstrom/chefdk_bootstrap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 ## Setup your laptop for Chef development in minutes
 
 Run one simple command to easily set up your Windows or Mac machine


### PR DESCRIPTION
The ChefDK_Bootstrap Gitter channel has never been used.
We don't want users to try to ask questions in that channel
and not get any response.

For now, the best way to ask for help is to open a GitHub issue.

[ci skip]