### PR TITLE
Remove the ohai.disabled_plugins config

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -62,7 +62,6 @@ EOF
 # create client.rb file so that Chef client can find its dependant cookbooks
 cat > "${tempInstallDir}/client.rb" <<EOF;
 cookbook_path File.join(Dir.pwd, 'berks-cookbooks')
-ohai.disabled_plugins = [:Passwd]
 EOF
 
 cat <<EOF;

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -65,7 +65,6 @@ cookbook '$bootstrapCookbook'
 
 $chefConfig = @"
 cookbook_path File.join(Dir.pwd, 'berks-cookbooks')
-ohai.disabled_plugins = [:Passwd]
 "@
 
 $introduction = @"


### PR DESCRIPTION
The config breaks on Windows because ohai is nil; on a Mac, it seems to
have no effect (it was there originally for performance to avoid loading
usernames)

Fixes #104 