### PR TITLE
With ChefSpec 4.6.0 we can reinstate skipped specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
       - chefdk
 
 # Don't `bundle install`
-install: echo "skip bundle install"
+install: echo 'skipping bundle install'
 
 # Ensure we make ChefDK's Ruby the default
 before_script:
@@ -17,9 +17,11 @@ before_script:
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version
-  - /opt/chefdk/embedded/bin/rubocop
   - /opt/chefdk/embedded/bin/foodcritic --version
+  # print out ChefSpec version
+  - /opt/chefdk/embedded/bin/chef gem list chefspec
+  - /opt/chefdk/embedded/bin/rubocop
   - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
-  - /opt/chefdk/embedded/bin/rspec spec
+  - /opt/chefdk/embedded/bin/rspec spec -f doc
 matrix:
   fast_finish: true

--- a/spec/unit/recipes/git_spec.rb
+++ b/spec/unit/recipes/git_spec.rb
@@ -3,17 +3,14 @@ RSpec.describe 'chefdk_bootstrap::git' do
     include_context 'windows_2012'
 
     it 'installs the correct version of Git' do
-      skip('Waiting on chocolatey_package matchers in ChefSpec 4.6')
       expect(windows_chef_run).to install_chocolatey_package('git')
     end
 
     it 'installs the Git credential helper' do
-      skip('Waiting on chocolatey_package matchers in ChefSpec 4.6')
       expect(windows_chef_run).to install_chocolatey_package('git-credential-manager-for-windows')
     end
 
     it 'installs poshgit' do
-      skip('Waiting on chocolatey_package matchers in ChefSpec 4.6')
       expect(windows_chef_run).to install_chocolatey_package('poshgit')
     end
   end

--- a/spec/unit/recipes/gitextensions_spec.rb
+++ b/spec/unit/recipes/gitextensions_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe 'chefdk_bootstrap::gitextensions' do
   include_context 'windows_2012'
 
   it 'installs GitExtensions via Chocolatey' do
-    skip('Waiting on chocolatey_package matchers in ChefSpec 4.6')
     expect(windows_chef_run).to install_chocolatey_package('gitextensions')
   end
 end

--- a/spec/unit/recipes/kdiff3_spec.rb
+++ b/spec/unit/recipes/kdiff3_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe 'chefdk_bootstrap::kdiff3' do
   include_context 'windows_2012'
 
   it 'installs the kdiff3 visual diff tool' do
-    skip('Waiting on chocolatey_package matchers in ChefSpec 4.6')
     expect(windows_chef_run).to install_chocolatey_package('kdiff3')
   end
 end

--- a/spec/unit/recipes/virtualbox_spec.rb
+++ b/spec/unit/recipes/virtualbox_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe 'chefdk_bootstrap::virtualbox' do
     include_context 'windows_2012'
 
     it 'installs Virtualbox via Chocolatey' do
-      skip('Waiting on chocolatey_package matchers in ChefSpec 4.6')
       expect(windows_chef_run).to install_chocolatey_package('virtualbox')
     end
   end


### PR DESCRIPTION
ChefSpec 4.6.0 added chocolately_package matchers