### PR TITLE
Recommend PowerShell 5 in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 * Install ChefDK 0.12 via bootstrap script
+* Add InSpec integration tests for each (Windows) component
+* Recommend PowerShell 5.0 instead of 4.0 in README
 
 ## 1.6.2
-* Use atom cookbook to install Atom
+* Use [atom cookbook](https://supermarket.chef.io/cookbooks/atom) to install Atom
 
 ## 1.6.1
 * Fix Atom install on Windows. Fixes [#109](https://github.com/Nordstrom/chefdk_bootstrap/issues/109).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run one simple command to easily set up your Windows or Mac machine
 for Chef cookbook development in about **20 minutes**.
 
 ## Before You Begin
-* If you are on a Windows machine, you will need at least PowerShell 3.0. We recommend [PowerShell 4.0](http://www.microsoft.com/en-us/download/details.aspx?id=40855) because it supports [Microsoft DSC](https://msdn.microsoft.com/en-us/PowerShell/DSC/overview).
+* If you are on a Windows machine, you will need at least PowerShell 3.0. We recommend [PowerShell 5.0](https://www.microsoft.com/en-us/download/details.aspx?id=50395) because it supports [Microsoft DSC](https://msdn.microsoft.com/en-us/PowerShell/DSC/overview).
 
 * If you are behind a proxy, you will need to export these [proxy environment variables](#if-you-are-behind-a-proxy) first.
 


### PR DESCRIPTION
[ci skip]

PowerShell 5 has been out for a while and seems quite stable. Chef users who want to use DSC will have a better experience with PowerShell 5.0 vs. 4.0.