### PR TITLE
Add ~/.kitchen/config.yml config file w/proxy pass-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Revision History for chefdk_bootstrap
 
 ## Unreleased
-* Fix #47 - Add kitchen config.yml file to pass through proxy settings (when needed)
+* Fix [#47](https://github.com/Nordstrom/chefdk_bootstrap/issues/47):
+  Add kitchen config.yml file to pass through proxy settings (when needed)
 
 ## 1.8.0
 * Fix [#130](https://github.com/Nordstrom/chefdk_bootstrap/issues/130):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for chefdk_bootstrap
 
+## Unreleased
+* Fix #47 - Add kitchen config.yml file to pass through proxy settings (when needed)
+
 ## 1.8.0
 * Fix [#130](https://github.com/Nordstrom/chefdk_bootstrap/issues/130):
   Move PowerShell Profile customizations to a PowerShell module on the $env:PSModulePath

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['chefdk_bootstrap']['package'].tap do |install|
   install['vagrant'] = true
   install['git'] = true
   install['chefdk_julia'] = false
+  install['kitchen_proxy'] = true
 end
 
 # platform specific

--- a/files/default/kitchen.config.yml
+++ b/files/default/kitchen.config.yml
@@ -1,0 +1,19 @@
+<%
+  proxy_vars = {}
+  %w(http_proxy https_proxy no_proxy).each do |envvar|
+     if ENV.key?(envvar)
+       proxy_vars[envvar] = ENV[envvar]
+     end
+  end
+%>
+---
+driver:
+  name: vagrant
+
+<% unless proxy_vars.empty? %>
+driver_config:
+<% proxy_vars.each do |envvar, value| %>
+  <%= envvar %>: '<%= value %>'
+<% end %>
+
+<% end %>

--- a/recipes/kitchen_proxy.rb
+++ b/recipes/kitchen_proxy.rb
@@ -1,0 +1,10 @@
+# Install a kitchen configuration file to pass through proxy settings
+# (only if there's a proxy at setup time and only if the file doesn't exist)
+
+directory File.join(Dir.home, '.kitchen')
+
+cookbook_file File.join(Dir.home, '.kitchen', 'config.yml') do
+  source 'kitchen.config.yml'
+  action :create_if_missing
+  only_if { node['chefdk_bootstrap']['proxy']['http'] }
+end

--- a/test/integration/default/kitchen_config_spec.rb
+++ b/test/integration/default/kitchen_config_spec.rb
@@ -1,0 +1,8 @@
+describe file('C:/Users/Vagrant/.kitchen/config.yml') do
+  if ENV['http_proxy']
+    it { should exist }
+    its('content') { should match(/<%/) }
+  else
+    it { should_not exist }
+  end
+end


### PR DESCRIPTION
Add a config file to pass through the http_proxy, https_proxy, and no_proxy values automatically to kitchen instances, with an option to disable it.

The config file is only added if there isn't already a ~/.kitchen/config.yml file.

Fix #47 

This passed `rspec`, `rake style`, and `kitchen verify` locally.