### PR TITLE
Add a temporary bypass for a vagrant problem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision History for chefdk_bootstrap
 
+## 2.2.1
+* Monkeypatch the vagrant helper library.  The way the mac os vagrant package name is computed
+has changed. A PR was submitted for the vagrant cookbook but hasn't been merged yet.
+
 ## 2.2.0
 * Create a test to check that the embedded version values have been changed.
 * Add code to create a global git configuration file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,3 +140,8 @@ export https_proxy=$http_proxy
 berks vendor cookbooks
 sudo -E chef-client -z -c ./client.rb -o chefdk_bootstrap
 ```
+
+To test the unreleased bootstrap.rb and cookbook work you can run:
+```bash
+./test/fixtures/scripts/testboot
+```

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -76,7 +76,7 @@ function Install-Project {
   $berksfile = @"
   source 'https://supermarket.chef.io'
 
-  cookbook '$bootstrapCookbook', '2.2.0'
+  cookbook '$bootstrapCookbook', '2.2.1'
 "@
 
   $chefConfig = @"

--- a/bootstrap.rb
+++ b/bootstrap.rb
@@ -76,7 +76,7 @@ module ChefDKBootstrap
     #  * :berks_source [String] private supermarket URL
     #  * :json_attributes [String] URL/path to the JSON file
     def initialize(options)
-      @cookbook = options[:cookbook] ? "'#{options[:cookbook]}'" : "'chefdk_bootstrap', '2.2.0'"
+      @cookbook = options[:cookbook] ? "'#{options[:cookbook]}'" : "'chefdk_bootstrap', '2.2.1'#{ENV['CHEFDK_BOOT_LOCAL']}"
     end
 
     # Creates berksfile in a temp directory

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,43 @@
+# Cookbook Name: chefdk_bootstrap
+# Library: helpers
+
+# Author:: Mark Gibbons
+# Copyright:: Copyright (c) 2018 Nordstrom, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Monkey patch the vagrant helper methods to find the mac vagrant packages
+# Work around an upstream error caused by a change in the vagrant package name scheme
+# See pull request https://github.com/jtimberman/vagrant-cookbook/pull/79
+
+module Vagrant
+  module Helpers
+    def package_extension
+      extension = value_for_platform_family(
+        'mac_os_x' =>  mac_os_x_extension,
+        'windows' => '.msi',
+        'debian' => '_x86_64.deb',
+        %w(rhel suse fedora) => '_x86_64.rpm'
+      )
+      raise ArgumentError "HashiCorp doesn't provide a Vagrant package for the #{node['platform']} platform." if extension.nil?
+
+      extension
+    end
+
+    def mac_os_x_extension
+      last_using_dmg = Gem::Version.new('1.9.2')
+      Gem::Version.new(package_version) > last_using_dmg ? '_x86_64.dmg' : '.dmg'
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer       'Nordstrom, Inc.'
 maintainer_email 'techcheftm@nordstrom.com'
 license          'Apache-2.0'
 description      'Bootstrap a developer workstation for local Chef development using the ChefDK'
-version          '2.2.0'
+version          '2.2.1'
 
 supports         'windows'
 supports         'mac_os_x'

--- a/test/fixtures/scripts/testboot
+++ b/test/fixtures/scripts/testboot
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Test chefdk boot on a mac, using a local copy of the cookbook
+# Set environment variable CHEFDK_VERSION to override the default version of chefdk
+# Set environment variable CHEFDK_BOOT_LOCAL to set a berksfile path to the local copy of the chefdk_bootstrap cookbook
+
+echo "Starting chefdk_bootstrap_nord bootstrap..."
+
+echo "Setting up proxy environment variables..."
+export http_proxy=http://webproxysea.nordstrom.net:8181
+export https_proxy=$http_proxy
+export no_proxy='localhost,127.0.0.1,nordstrom.net'
+
+# Send these attributes into the bootstrap to be passed into chef-client
+CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES="https://git.nordstrom.net/projects/CHF/repos/chefdk_bootstrap_nord/browse/attributes.json?raw"
+[ -z "$CHEFDK_VERSION" ] && CHEFDK_VERSION="2.4.17"
+[ -z "$CHEFDK_BOOT_LOCAL" ] && CHEFDK_BOOT_LOCAL=", path: '$(pwd)'" && export CHEFDK_BOOT_LOCAL
+
+echo "Starting chefdk_bootstrap..."
+#ruby -e "$(cat bootstrap.rb)" - --version $CHEFDK_VERSION
+ruby -e "$(cat bootstrap.rb)" - --json-attributes $CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES --version $CHEFDK_VERSION
+
+# Check to see if the .chef folder exists and already has files in it
+if [[ -d ~/.chef && "$(ls -A ~/.chef)" ]]; then
+  echo "Chef configuration appears to already be set up."
+else
+  echo "Configuring chef..."
+  echo "(You may be prompted for your password to access git.nordstrom.net)"
+  git clone https://$USER@git.nordstrom.net/scm/chf/dotchef.git ~/.chef
+fi


### PR DESCRIPTION
The package name for mac os packages changed in version 1.9.3. Deal with it.