### PR TITLE
Version 2.4.0

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -19,3 +19,4 @@ metadata
 
 # Enable Chocolatey package installs behind a proxy
 cookbook 'win_proxy', path: './test/fixtures/cookbooks/win_proxy'
+cookbook 'vagrant', path: '~/dev/community/vagrant-cookbook'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision History for chefdk_bootstrap
 
+## 2.4.0
+* Don't install virtual box on a guest system
+* Use version 5.2.8 of virtual box on the mac
+* Fix the vagrant helper library to use the right windows package names
+
 ## 2.3.0
 * Use chef_ca to add a Certificate Authority cert bundle to the chefdk cacert.pem file
 The goal is to allow authorized access to locally signed supermarket and chef server

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Nordstrom, Inc.
+# Copyright 2015, 2018 Nordstrom, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ default['chefdk_bootstrap']['package'].tap do |install|
   install['kitchen_proxy'] = true
   install['gitconfig'] = false
 end
+
+# No virtual box on vm
+default['chefdk_bootstrap']['package']['virtualbox'] = false if node['virtualization']['system']['role'] == 'guest'
 
 # platform specific
 case node['platform_family']
@@ -71,8 +74,8 @@ default['chefdk_bootstrap']['proxy']['http'] = ENV['http_proxy'] # 'http://mypro
 # Skip the proxy for these domains and IPs. This should be a comma-separated string
 default['chefdk_bootstrap']['proxy']['no_proxy'] = ENV['no_proxy'] # 'example.com,localhost,127.0.0.1'
 
-default['chefdk_bootstrap']['virtualbox']['source'] = 'http://download.virtualbox.org/virtualbox/5.0.14/VirtualBox-5.0.14-105127-OSX.dmg'
-default['chefdk_bootstrap']['virtualbox']['checksum'] = '4de41068712eb819749b5376c90dca47f9a1d6eecf4c516d83269ac12add2aa4'
+default['chefdk_bootstrap']['virtualbox']['source'] = 'http://download.virtualbox.org/virtualbox/5.2.8/VirtualBox-5.2.8-121009-OSX.dmg'
+default['chefdk_bootstrap']['virtualbox']['checksum'] = '97764ad37c5fafdeccecfb660ce056f625e9048890af772befe0330ed2def1d8'
 
 # Default Atom plugins
 default['atom']['packages'] = %w(language-powershell linter linter-cookstyle linter-erb linter-foodcritic linter-rubocop merge-conflicts rubocop-auto-correct)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,14 +19,15 @@
 
 # Monkey patch the vagrant helper methods to find the mac vagrant packages
 # Work around an upstream error caused by a change in the vagrant package name scheme
-# See pull request https://github.com/jtimberman/vagrant-cookbook/pull/79
+# See pull request https://github.com/jtimberman/vagrant-cookbook/pull/79 - Mac extensions in master waiting for it to be published
+# See pull request https://github.com/jtimberman/vagrant-cookbook/pull/80 - Windows extensions
 
 module Vagrant
   module Helpers
     def package_extension
       extension = value_for_platform_family(
         'mac_os_x' =>  mac_os_x_extension,
-        'windows' => '.msi',
+        'windows' => windows_extension,
         'debian' => '_x86_64.deb',
         %w(rhel suse fedora) => '_x86_64.rpm'
       )
@@ -35,9 +36,23 @@ module Vagrant
       extension
     end
 
+    def extract_checksum(sha256sums)
+      raise "SHA 256 sum not found for the Vagrant package #{package_name}" unless sha256sums.grep(/#{package_name}/)[0].respond_to?(:split)
+      sha256sums.grep(/#{package_name}/)[0].split.first
+    end
+
     def mac_os_x_extension
       last_using_dmg = Gem::Version.new('1.9.2')
       Gem::Version.new(package_version) > last_using_dmg ? '_x86_64.dmg' : '.dmg'
+    end
+
+    def windows_extension
+      last_using_msi = Gem::Version.new('1.9.5')
+      Gem::Version.new(package_version) > last_using_msi ? "#{windows_machine}.msi" : '.msi'
+    end
+
+    def windows_machine
+      node['kernel']['machine'] == 'x86_64' ? '_x86_64' : '_i686'
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer       'Nordstrom, Inc.'
 maintainer_email 'techcheftm@nordstrom.com'
 license          'Apache-2.0'
 description      'Bootstrap a developer workstation for local Chef development using the ChefDK'
-version          '2.3.0'
+version          '2.4.0'
 
 supports         'windows'
 supports         'mac_os_x'

--- a/recipes/atom_windows.rb
+++ b/recipes/atom_windows.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 package 'Atom' do # ~FC009
-  source node['atom']['source_url']
+  source node['chefdk_bootstrap']['atom']['source_url']
   remote_file_attributes(
     path: File.join(Chef::Config[:file_cache_path], 'AtomSetup.exe')
   )


### PR DESCRIPTION
Don't install virtual box on a guest system
Use version 5.2.8 of virtual box on the mac
Fix the vagrant helper library to use the right windows package names