### PR TITLE
Bump vagrant

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -19,4 +19,4 @@ metadata
 
 # Enable Chocolatey package installs behind a proxy
 cookbook 'win_proxy', path: './test/fixtures/cookbooks/win_proxy'
-cookbook 'vagrant', path: '~/dev/community/vagrant-cookbook'
+cookbook 'vagrant', path: '~/cookbooks/vagrant'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.4.1
 * Bump the vagrant cookbook version to ~> 0.9. The new vagrant default version is 2.0.3
+* Exclude the passwd ohai plugin. This change eliminates a 6 minute hang at the start of the install that some users were experiencing.
 
 ## 2.4.0
 * Don't install virtual box on a guest system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for chefdk_bootstrap
 
+## 2.4.1
+* Bump the vagrant cookbook version to ~> 0.9. The new vagrant default version is 2.0.3
+
 ## 2.4.0
 * Don't install virtual box on a guest system
 * Use version 5.2.8 of virtual box on the mac

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -76,7 +76,7 @@ function Install-Project {
   $berksfile = @"
   source 'https://supermarket.chef.io'
 
-  cookbook '$bootstrapCookbook', '2.4.0'
+  cookbook '$bootstrapCookbook', '2.4.1'
 "@
 
   $chefConfig = @"

--- a/bootstrap.rb
+++ b/bootstrap.rb
@@ -76,7 +76,7 @@ module ChefDKBootstrap
     #  * :berks_source [String] private supermarket URL
     #  * :json_attributes [String] URL/path to the JSON file
     def initialize(options)
-      @cookbook = options[:cookbook] ? "'#{options[:cookbook]}'" : "'chefdk_bootstrap', '2.4.0'#{ENV['CHEFDK_BOOT_LOCAL']}"
+      @cookbook = options[:cookbook] ? "'#{options[:cookbook]}'" : "'chefdk_bootstrap', '2.4.1'#{ENV['CHEFDK_BOOT_LOCAL']}"
     end
 
     # Creates berksfile in a temp directory
@@ -122,6 +122,7 @@ module ChefDKBootstrap
 
       clientrb_content = <<-EOH.gsub(/^\s+/, '')
         cookbook_path '#{File.join(Dir.pwd, 'berks-cookbooks')}'
+        ohai.disabled_plugins = [ :Passwd ]
         EOH
       @path = File.join(@tempdir, 'client.rb')
       File.open(@path, 'w') { |c| c.write(clientrb_content) }

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer       'Nordstrom, Inc.'
 maintainer_email 'techcheftm@nordstrom.com'
 license          'Apache-2.0'
 description      'Bootstrap a developer workstation for local Chef development using the ChefDK'
-version          '2.4.0'
+version          '2.4.1'
 
 supports         'windows'
 supports         'mac_os_x'
@@ -32,7 +32,7 @@ depends          'chocolatey', '~> 1.0'
 depends          'git', '~> 8.0'
 depends          'homebrew', '~> 4.3'
 depends          'line', '~> 1.0'
-depends          'vagrant', '~> 0.7.2'
+depends          'vagrant', '~> 0.9'
 depends          'windows', '~> 3.4'
 
 # temporary while atom is embedded

--- a/test/fixtures/scripts/testboot
+++ b/test/fixtures/scripts/testboot
@@ -7,9 +7,9 @@
 echo "Starting chefdk_bootstrap_nord bootstrap..."
 
 echo "Setting up proxy environment variables..."
-export http_proxy=http://webproxysea.nordstrom.net:8181
-export https_proxy=$http_proxy
-export no_proxy='localhost,127.0.0.1,nordstrom.net'
+# export http_proxy=http://webproxysea.nordstrom.net:8181
+# export https_proxy=$http_proxy
+# export no_proxy='localhost,127.0.0.1,nordstrom.net'
 
 # Send these attributes into the bootstrap to be passed into chef-client
 CHEFDK_BOOTSTRAP_JSON_ATTRIBUTES="https://git.nordstrom.net/projects/CHF/repos/chefdk_bootstrap_nord/browse/attributes.json?raw"


### PR DESCRIPTION
Exclude the passwd ohai plugin from the install chef client run.  Some users were experiencing a 6 minute wait at install time.